### PR TITLE
Link to DOI resolver if URL not set

### DIFF
--- a/src/pubvis.js
+++ b/src/pubvis.js
@@ -74,6 +74,11 @@ PUBVIS = function () {
                     var key = keys[i];
                     newEntryTags[key.toLowerCase()] = entryTags[key];
                 }
+            
+                if (newEntryTags['doi'] != undefined && newEntryTags['url'] == undefined){
+                    newEntryTags['url'] = 'http://dx.doi.org/' + newEntryTags['doi'];
+                }
+            
                 bigJson[e].entryTags = newEntryTags;
                 bigJson[e].entryType = bigJson[e].entryType.toLowerCase();
         }


### PR DESCRIPTION
If the ``url`` tag is not set, but the ``doi`` tag is, then set the url to be the doi resolver.